### PR TITLE
Added info about Hacksoc's Google Calendar

### DIFF
--- a/_posts/2015-10-01-hacksoc-calendar.md
+++ b/_posts/2015-10-01-hacksoc-calendar.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: Hacksoc Events Calendar
+author: Jamie Tanna (HackSoc 2015-16 General Secretary)
+---
+
+We've officially released our calendar for the year's events!
+
+This year we have a Google calendar that will be updated with new events as-and-when they are announced, so you'll always be in the loop.
+
+The calendar, for reference, can be seen here:
+
+<iframe src="https://www.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=pqclo0bjutp9ld8qpdbtcf3jv8%40group.calendar.google.com&amp;color=%23125A12&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+But who wants to constantly browse to our site to check this out? To make your lives easier, you can add it into your own calendar client via the following methods:
+
+- [Google Calendar](https://support.google.com/calendar/answer/37100)
+- [Apple Calendar](https://support.apple.com/kb/PH11524)
+
+These will require you to have one of these links, which will make it possible for you to import the full calendar straight in:
+
+- [ICAL file format (`.ics`)](https://www.google.com/calendar/ical/pqclo0bjutp9ld8qpdbtcf3jv8%40group.calendar.google.com/public/basic.ics)
+- [XML file format](https://www.google.com/calendar/feeds/pqclo0bjutp9ld8qpdbtcf3jv8%40group.calendar.google.com/public/basic)
+
+For other clients, ping us on [mail@hacksocnotts.co.uk](mailto:mail@hacksocnotts.co.uk) and we'll point you in the right direction.

--- a/calendar.md
+++ b/calendar.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Calendar
+permalink: /calendar/
+---
+
+### Hacksoc's 2015-16 Calendar
+
+We've officially released our calendar for the year's events!
+
+This year we have a Google calendar that will be updated with new events as-and-when they are announced, so you'll always be in the loop.
+
+The calendar, for reference, can be seen here:
+
+<iframe src="https://www.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=pqclo0bjutp9ld8qpdbtcf3jv8%40group.calendar.google.com&amp;color=%23125A12&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+For information about how to add it to your own calendar client, please visit the [blog post]({% post_url 2015-10-01-hacksoc-calendar %}).


### PR DESCRIPTION
Created both a page, which can be a static reference that people will
be able to easily remember and link. It can also be used in future
years, just have the content changes.

We provide an embedded copy of the calendar for the at-a-glance
reference, and for those who haven't yet integrated it into their own
calendar. There are also links to the setup instructions for Google and
Apple calendars, and a note to contact us if they're not using either
clients.

As we've added a page, there is now a direct link from the header menu
to the calendar, so there's a very quick and easy way to access it from
whichever page we're on.
