### PR TITLE
Programatically display contributors to the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ To replace : http://www.hacksocnotts.co.uk/
 	* GitHub may send your email or info@hacksocnotts.co.uk with failure information (although it's not always very helpful)
 	* Ask @jay-to-the-dee (Dilks) or @jamietanna if you're still stuck :)
 
+## Testing the Contributors Page Locally
+
+In order to test the Contributors page locally, you will be required to follow the steps at <https://help.github.com/articles/repository-metadata-on-github-pages/#using-repository-metadata-locally>, to interface with the Github API locally. With this done, you can then run `env JEKYLL_GITHUB_TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX bundle exec jekyll serve`.
+
 ## Created with Jekyll
 
 A free and open-source blogging platform [Jekyll](http://jekyllrb.com).

--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,12 @@
 baseurl: "/" # the subpath of your site, e.g. /blog/
 url: "http://www.hacksocnotts.github.io" # the base hostname & protocol for your site
 
+repository: HackSocNotts/HackSocNotts.github.io
+
 gems:
   - jekyll-paginate
   - rouge
+  - jekyll-github-metadata
 
 # THEME-SPECIFIC CONFIGURATION
 theme_specific:
@@ -24,7 +27,7 @@ theme_specific:
 
   header_text_feature_image:
   footer_text: >
-   Created by members of <a href="//github.com/orgs/HackSocNotts/people">HackSoc</a>, and available under the terms of the <a href="https://github.com/HackSocNotts/HackSocNotts.github.io/blob/master/LICENSE">GNU General Public License v3</a>.
+   <a href="/contributors/">Created by members</a> of <a href="//github.com/orgs/HackSocNotts/people">HackSoc</a>, and available under the terms of the <a href="https://github.com/HackSocNotts/HackSocNotts.github.io/blob/master/LICENSE">GNU General Public License v3</a>.
 
   # Icons
   rss: false

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Contributors
+permalink: /contributors/
+---
+
+### Contributors
+
+We'd like to say a huge thank you to the following members for their contributions to the site:
+
+{% for contributor in site.github.contributors %}
+- <img height="32px" src="{{ contributor.avatar_url}}"/>&nbsp;[{{ contributor.login}}]({{contributor.html_url}}), {{ contributor.contributions}} contributions
+{% endfor %}
+


### PR DESCRIPTION
Using the `jekyll-github-metadata` plugin, we can work out who has
contributed to the HackSocNotts site, as well as how many contributions
they've made (although no information about SLOC or any other metrics).