### PR TITLE
Remove any unnecessary files for Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,4 +63,9 @@ sass:
   sass_dir: _sass
   style: :compressed
 
-exclude: [vendor]
+exclude:
+    - vendor
+    - Gemfile*
+    - TODO
+    - LICENSE*
+    - README*


### PR DESCRIPTION
Jekyll by default will serve any files in our directory; such as
READMEs or our `Gemfile`s. These files don't quite leak information, but
aren't needed in the output, so let's just force ignore them from
Jekyll.