### PR TITLE
Fix for incorrect post links after first index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ layout: default
     <div class="post-teaser">
       <header>
         <h1>
-          <a class="post-link" href="{{ post.url | remove_first: '/' | prepend: site.baseurl }}">
+          <a class="post-link" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
             {{ post.title }}
           </a>
         </h1>
@@ -25,7 +25,7 @@ layout: default
       </header>
       <div class="excerpt">
         {{ post.excerpt }}
-        <a class="button" href="{{ post.url | remove_first: '/' | prepend: site.baseurl }}">
+        <a class="button" href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
           {{ site.theme_specific.str_continue_reading }}
         </a>
       </div>


### PR DESCRIPTION
This PR attempts to fix #23, where links to posts on the second page and onwards of the index lead to 404 pages. The urls of the pages are correct except they have something along the lines of "/page2/" between the domain and the post url.

From what I can tell, the reason that this happens is that GitHub pages doesn't use the value of the baseurl variable set in the config. Instead, it seems to overwrite it with what it thinks it should be based on where it's serving your site. So, on hacksocnotts.co.uk, the baseurl seems to be getting set to an empty string, because it's at the root of the domain.

Then, the linking for the posts uses:
`{{ post.url | remove_first: '/' | prepend: site.baseurl }}`
`post.url` is the url of the post with a slash at the start of it. The thinking behind removing the first slash seems to be so that there aren't two slashes, one from `post.url` and the other from `site.baseurl`, but since `site.baseurl` is empty, the result is `post.url` without a preceding slash. This is then handled by the browser as trying to navigate to a file relative to the current directory, when it should instead be navigating to a file relative to the root of the domain.

My proposed fix for this is to not use this:
`{{ post.url | prepend: site.baseurl | replace: '//', '/' }}`
Here, we do not use the `remove_first: '/'` filter. Instead, we simply prepend the baseurl and then replace any repeated slashes with a single slash. This is the same approach used in the links for the pagination buttons a few lines later in the same file.